### PR TITLE
Create activate acount

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,7 +92,10 @@ model users {
   bloodType          String?   @db.VarChar(3)
   eps                String?   @db.VarChar(60)
   status             Boolean   @default(true)
+  activate           Boolean   @default(false)
+  activationToken    String?   @unique @db.VarChar(255)
   resetPasswordToken String?   @unique @db.VarChar(255)
+  passwordUpdatedAt  DateTime  @default(now()) // Fecha de última actualización de la contraseña
 
   role           roles          @relation(fields: [idRole], references: [id], onDelete: Cascade)
   municipalities municipalities @relation(fields: [idMunicipality], references: [id], onDelete: Cascade)

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import {
   Body,
   Controller,
@@ -7,17 +5,20 @@ import {
   HttpStatus,
   Patch,
   Post,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { SignUpDto } from './dto/sign-up';
 import { LogInDto } from './dto/log-in';
 import { IsPublic } from './decorators/public.decorator';
 import { ResetPasswordDto } from './dto/request-reset-password.dto';
+import { ActivateUserDto } from './dto/activate-user.dto';
 import { SubmitEmailTokenDto } from './dto/submit-email-token.dto';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(private readonly authService: AuthService) {}
 
   @IsPublic()
   @Post('log-in')
@@ -34,15 +35,11 @@ export class AuthController {
   async signUp(@Body() signUpDto: SignUpDto) {
     try {
       const user = await this.authService.signUp(signUpDto);
-      if (!user) {
-        throw new HttpException('User already exists', HttpStatus.BAD_REQUEST);
-      }
       return user;
     } catch (error) {
       throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
     }
   }
-
 
   @IsPublic()
   @Patch('reset-password')
@@ -54,10 +51,19 @@ export class AuthController {
     }
   }
 
-
   @IsPublic()
   @Post('submit-token')
   async submitEmailToken(@Body() submitEmailTokenDto: SubmitEmailTokenDto) {
     return this.authService.submitEmailToken(submitEmailTokenDto);
+  }
+
+  @IsPublic()
+  @Post('activate')
+  async activate(@Body() activateUserDto: ActivateUserDto) {
+    try {
+      return await this.authService.activateUser(activateUserDto);
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    }
   }
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -5,8 +5,6 @@ import {
   HttpStatus,
   Patch,
   Post,
-  UsePipes,
-  ValidationPipe,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { SignUpDto } from './dto/sign-up';
@@ -25,8 +23,13 @@ export class AuthController {
   async logIn(@Body() logInDto: LogInDto) {
     try {
       return await this.authService.logIn(logInDto);
-    } catch (error) {
-      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    } catch (error: unknown) {
+      // Tipamos el error como unknown y luego verificamos su estructura
+      const errorMessage =
+        error instanceof HttpException
+          ? error.message
+          : 'Invalid email or password';
+      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
     }
   }
 
@@ -36,8 +39,11 @@ export class AuthController {
     try {
       const user = await this.authService.signUp(signUpDto);
       return user;
-    } catch (error) {
-      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    } catch (error: unknown) {
+      // Convertimos el mensaje de error a string de forma segura
+      const errorMessage =
+        error instanceof Error ? error.message : 'An unknown error occurred';
+      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
     }
   }
 
@@ -46,8 +52,10 @@ export class AuthController {
   async resetPassword(@Body() resetPasswordDto: ResetPasswordDto) {
     try {
       return await this.authService.resetPassword(resetPasswordDto);
-    } catch (error) {
-      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'An unknown error occurred';
+      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
     }
   }
 
@@ -62,8 +70,10 @@ export class AuthController {
   async activate(@Body() activateUserDto: ActivateUserDto) {
     try {
       return await this.authService.activateUser(activateUserDto);
-    } catch (error) {
-      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'An unknown error occurred';
+      throw new HttpException(errorMessage, HttpStatus.BAD_REQUEST);
     }
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { PrismaService } from 'src/config/prisma/prisma.service';
 import { compare, encrypt } from 'src/providers/bcrypt';
 import { BadRequestException, Injectable } from '@nestjs/common';
@@ -38,7 +39,7 @@ export class AuthService {
         },
       });
 
-      const { password: _, ...userWithoutPassword } = user;
+      const { password, ...userWithoutPassword } = user;
 
       return {
         ...userWithoutPassword,
@@ -74,7 +75,7 @@ export class AuthService {
 
     if (!isPasswordMatch) throw new BadRequestException('Invalid credentials');
 
-    const { password: _, ...userWithoutPassword } = userFound;
+    const { password, ...userWithoutPassword } = userFound;
 
     const payload = {
       ...userWithoutPassword,

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { PrismaService } from 'src/config/prisma/prisma.service';
 import { compare, encrypt } from 'src/providers/bcrypt';
 import { BadRequestException, Injectable } from '@nestjs/common';
@@ -6,7 +5,9 @@ import { SignUpDto } from './dto/sign-up';
 import { JwtService } from '@nestjs/jwt';
 import { LogInDto } from './dto/log-in';
 import { ResetPasswordDto } from './dto/request-reset-password.dto';
+import { ActivateUserDto } from './dto/activate-user.dto';
 import { SubmitEmailTokenDto } from './dto/submit-email-token.dto';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class AuthService {
@@ -24,14 +25,30 @@ export class AuthService {
 
     if (!userFound) {
       const hashedPassword = await encrypt(signUpDto.password);
+
+      // Generate activation token
+      const activationToken = crypto.randomBytes(32).toString('hex');
+
       const user = await this.prisma.users.create({
-        data: { ...signUpDto, password: hashedPassword },
+        data: {
+          ...signUpDto,
+          password: hashedPassword,
+          activate: false,
+          activationToken,
+        },
       });
 
       const { password: _, ...userWithoutPassword } = user;
 
-      return userWithoutPassword;
+      return {
+        ...userWithoutPassword,
+        message:
+          'User created successfully. Please activate your account using the activation token.',
+        activationToken, // Return token so it can be used for activation
+      };
     }
+
+    throw new BadRequestException('User already exists');
   }
 
   async logIn(logInDto: LogInDto) {
@@ -42,6 +59,13 @@ export class AuthService {
     });
 
     if (!userFound) throw new BadRequestException('Invalid credentials');
+
+    // Check if account is activated
+    if (!userFound.activate) {
+      throw new BadRequestException(
+        'Account not activated. Please activate your account first.',
+      );
+    }
 
     const isPasswordMatch = await compare(
       logInDto.password,
@@ -54,12 +78,15 @@ export class AuthService {
 
     const payload = {
       ...userWithoutPassword,
+      passwordUpdatedAt: userFound.passwordUpdatedAt, // Incluir la fecha de última actualización de la contraseña
     };
 
     const accessToken = await this.jwtService.signAsync(payload);
 
     return { accessToken };
   }
+
+  // Reset password
 
   async resetPassword(resetPasswordDto: ResetPasswordDto) {
     const userFound = await this.prisma.users.findUnique({
@@ -79,6 +106,7 @@ export class AuthService {
       data: {
         password: hashedPassword,
         resetPasswordToken: null,
+        passwordUpdatedAt: new Date(), // Actualizar la fecha de última actualización de la contraseña
       },
     });
 
@@ -91,13 +119,15 @@ export class AuthService {
         email: submitEmailTokenDto.email,
       },
     });
-    
+
     if (!user) {
       throw new BadRequestException('User not found');
     }
-    
-    const resetToken = await encrypt(submitEmailTokenDto.email + Date.now().toString());
-    
+
+    const resetToken = await encrypt(
+      submitEmailTokenDto.email + Date.now().toString(),
+    );
+
     await this.prisma.users.update({
       where: { email: submitEmailTokenDto.email },
       data: {
@@ -105,9 +135,69 @@ export class AuthService {
       },
     });
 
-    return { 
+    return {
       message: 'Reset password token has been generated',
-      token: resetToken
+      token: resetToken,
     };
+  }
+
+  //Actiavte acount
+
+  async sendActivationToken(email: string) {
+    const user = await this.prisma.users.findUnique({
+      where: { email },
+    });
+
+    if (!user) {
+      throw new BadRequestException('User not found');
+    }
+
+    if (user.activate) {
+      throw new BadRequestException('Account is already activated');
+    }
+
+    // Generate new activation token
+    const activationToken = crypto.randomBytes(32).toString('hex');
+
+    await this.prisma.users.update({
+      where: { email },
+      data: { activationToken },
+    });
+
+    return {
+      message: 'Activation token has been generated',
+      token: activationToken,
+    };
+  }
+
+  async activateUser(activateUserDto: ActivateUserDto) {
+    const { email, activationUserToken } = activateUserDto;
+
+    // Buscar al usuario con el token de activación
+    const user = await this.prisma.users.findFirst({
+      where: {
+        email,
+        activationToken: activationUserToken,
+        activate: false, // Verificar que la cuenta no esté activada
+      },
+    });
+
+    // Validar si el usuario existe y el token es válido
+    if (!user) {
+      throw new BadRequestException(
+        'Invalid activation token or account already activated',
+      );
+    }
+
+    // Actualizar el estado de activación del usuario
+    await this.prisma.users.update({
+      where: { id: user.id },
+      data: {
+        activate: true, // Activar la cuenta
+        activationToken: null, // Eliminar el token de activación
+      },
+    });
+
+    return { message: 'Account activated successfully' };
   }
 }

--- a/src/modules/auth/dto/activate-user.dto.ts
+++ b/src/modules/auth/dto/activate-user.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class ActivateUserDto {
+  @ApiProperty({ required: true })
+  @IsNotEmpty()
+  @IsString()
+  email: string;
+
+  @ApiProperty({ required: true })
+  @IsNotEmpty()
+  @IsString()
+  activationUserToken: string;
+}

--- a/src/modules/auth/dto/request-reset-password.dto.ts
+++ b/src/modules/auth/dto/request-reset-password.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsString } from "class-validator";
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class ResetPasswordDto {
   @ApiProperty({ required: true })

--- a/src/modules/auth/dto/submit-email-token.dto.ts
+++ b/src/modules/auth/dto/submit-email-token.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsEmail } from "class-validator";
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsEmail } from 'class-validator';
 
 export class SubmitEmailTokenDto {
   @ApiProperty({ required: true })

--- a/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/src/modules/auth/guards/jwt-auth.guard.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from 'src/config/prisma/prisma.service';
 import { Request } from 'express';
 import { PUBLIC_KEY } from 'src/utils/constants/key-decorator';
 
@@ -17,6 +18,7 @@ export class JwtAuthGuard implements CanActivate {
   constructor(
     private jwtService: JwtService,
     private readonly reflector: Reflector,
+    private readonly prisma: PrismaService, // Inyección de PrismaService
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -37,9 +39,25 @@ export class JwtAuthGuard implements CanActivate {
         secret: process.env.JWT_SECRET,
       });
 
+      // Validar si el token fue emitido antes de la última actualización de la contraseña
+      const user = await this.prisma.users.findUnique({
+        where: { id: payload.id },
+      });
+
+      if (!user) {
+        throw new UnauthorizedException('User not found');
+      }
+
+      if (
+        payload.passwordUpdatedAt &&
+        new Date(payload.passwordUpdatedAt) < new Date(user.passwordUpdatedAt)
+      ) {
+        throw new UnauthorizedException('Token is no longer valid');
+      }
+
       request['user'] = payload;
-    } catch {
-      throw new UnauthorizedException();
+    } catch (error) {
+      throw new UnauthorizedException(error.message);
     }
     return true;
   }

--- a/src/modules/users/entities/user.entity.ts
+++ b/src/modules/users/entities/user.entity.ts
@@ -16,5 +16,8 @@ export class User {
   bloodType: string;
   eps: string;
   status: boolean;
+  //auth
+  activate: boolean;
+  activationToken: string;
   resetPasswordToken: string;
 }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -11,6 +11,8 @@ import {
   HttpException,
   HttpStatus,
   UseGuards,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -54,6 +56,7 @@ export class UsersController {
 
   @Roles('ADMIN')
   @Post()
+  @UsePipes(new ValidationPipe())
   async create(@Body() createUserDto: CreateUserDto) {
     try {
       return await this.usersService.create(createUserDto);

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -49,9 +49,9 @@ export class UsersService {
       return {
         ...user,
         message: 'User created successfully. Please activate your account.',
-        activationToken, // Return token so it can be used for activation
+        activationToken,
       };
-    } catch (error) {
+    } catch {
       throw new HttpException(
         'Error creating user. Please try again later.',
         HttpStatus.BAD_REQUEST,
@@ -108,7 +108,7 @@ export class UsersService {
         data: { activationToken: token },
       });
       return token;
-    } catch (error) {
+    } catch {
       throw new HttpException(
         'Error generating activation token',
         HttpStatus.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Además de crear la activación de cuenta, también se implemento lo que viene a ser la inhabilitación de un token después de que su respectiva contraseña haya sido cambiada, por lo tanto si un usuario generaba un primer token con su primer contraseña pero después cambiaba su contraseña y quería volver a usar el token de la primer contraseña no se puede hacer 